### PR TITLE
Add xterm's 256 color support

### DIFF
--- a/lib/colors.rb
+++ b/lib/colors.rb
@@ -8,6 +8,7 @@ require_relative "colors/hsla"
 require_relative "colors/husl"
 require_relative "colors/rgb"
 require_relative "colors/rgba"
+require_relative "colors/xterm256"
 require_relative "colors/xyy"
 require_relative "colors/xyz"
 

--- a/lib/colors/xterm256.rb
+++ b/lib/colors/xterm256.rb
@@ -1,0 +1,56 @@
+module Colors
+  class Xterm256 < AbstractColor
+    include Helper
+
+    def initialize(code)
+      unless 16 <= code && code <= 255
+        raise ArgumentError, "code should be in 16..255, but #{code} is given"
+      end
+      @code = code
+    end
+
+    attr_reader :code
+
+    def ==(other)
+      case other
+      when Xterm256
+        code == other.code
+      else
+        super
+      end
+    end
+
+    def to_rgb_components
+      if code < 232
+        x = code - 16
+        x, b = x.divmod(6)
+        r, g = x.divmod(6)
+        r = 40*r + 55 if r > 0
+        g = 40*g + 55 if g > 0
+        b = 40*b + 55 if b > 0
+        [
+          canonicalize_component_from_integer(r, :r),
+          canonicalize_component_from_integer(g, :r),
+          canonicalize_component_from_integer(b, :r)
+        ]
+      else
+        grey = to_grey_level
+        [grey, grey, grey]
+      end
+    end
+
+    def to_grey_level
+      if code < 232
+        r, g, b = to_rgb_components
+        x, y, z = Convet.rgb_to_xyz(r, g, b)
+      else
+        grey = 10*(code - 232) + 8
+        canonicalize_component_from_integer(grey, :grey)
+      end
+    end
+
+    def to_rgb
+      RGB.new(*to_rgb_components)
+    end
+  end
+end

--- a/test/test-xterm256.rb
+++ b/test/test-xterm256.rb
@@ -1,0 +1,76 @@
+class ColorsXterm256Test < Test::Unit::TestCase
+  include TestHelper
+
+  sub_test_case(".new") do
+    sub_test_case("with color code") do
+      test("the regular case") do
+        codes = [16, 255]
+        colors = codes.map {|i| Colors::Xterm256.new(i) }
+        assert_equal(codes,
+                     colors.map(&:code))
+      end
+
+      data do
+        (0..15).map { |code|
+          ["ANSI color #{code}", code]
+        }.to_h
+      end
+      def test_ansi_color_code(code)
+        assert_raise(ArgumentError) do
+          Colors::Xterm256.new(code)
+        end
+      end
+
+      test("the negative argument") do
+        assert_raise(ArgumentError) do
+          Colors::Xterm256.new(-1)
+        end
+      end
+
+      test("too large argument") do
+        assert_raise(ArgumentError) do
+          Colors::Xterm256.new(256)
+        end
+      end
+    end
+  end
+
+  test("==") do
+    assert { Colors::Xterm256.new(16) == Colors::Xterm256.new(16) }
+    assert { Colors::Xterm256.new(132) == Colors::Xterm256.new(132) }
+  end
+
+  test("!=") do
+    assert { Colors::Xterm256.new(16) != Colors::Xterm256.new(17) }
+  end
+
+  data do
+    data_set = {}
+    # colors 16-231 are a 6x6x6 color cube
+    (0...6).each do |r|
+      (0...6).each do |g|
+        (0...6).each do |b|
+          code = 6*(6*r + g) + b + 16
+          red   = (r > 0) ? 40*r + 55 : r
+          green = (g > 0) ? 40*g + 55 : g
+          blue  = (b > 0) ? 40*b + 55 : b
+          label = "Color #{code} is rgb(#{red}, #{green}, #{blue})"
+          data_set[label] = [code, Colors::RGB.new(red, green, blue)]
+        end
+      end
+    end
+    # colors 232-256 are grayscale colors
+    (0...24).each do |y|
+      code = 232 + y
+      level = 10*y + 8
+      label = "Color #{code} is gray(#{level})"
+      data_set[label] = [code, Colors::RGB.new(level, level, level)]
+    end
+    data_set
+  end
+  def test_to_rgb(data)
+    code, rgb = data
+    assert_equal(rgb,
+                 Colors::Xterm256.new(code).to_rgb)
+  end
+end


### PR DESCRIPTION
`Colors::Xterm256` supports to create a new color space defined in the color code of xterm's 256 colors.
We can convert a `Colors::Xterm256` to a `Colors::RGB` by `Colors::Xterm256#to_rgb` method.