### PR TITLE
CSS3 support

### DIFF
--- a/lib/colors.rb
+++ b/lib/colors.rb
@@ -11,6 +11,7 @@ require_relative "colors/rgba"
 require_relative "colors/xterm256"
 require_relative "colors/xyy"
 require_relative "colors/xyz"
+require_relative "colors/css3"
 
 require_relative "colors/color_data"
 require_relative "colors/named_colors"

--- a/lib/colors/css3.rb
+++ b/lib/colors/css3.rb
@@ -1,0 +1,105 @@
+module Colors
+
+  module CSSUtil
+
+    # For RGB, CSS clamps negative values to zero and anything over 255 to 255
+    def self.clamp_int(strval)
+      value = strval.to_i
+      return 0 if value < 0
+      return 255 if value > 255
+      value
+    end
+    
+    # Rationalize a percentage string, e.g.:  "1.2%"
+    # takes advantage of #to_r ignoring the '%' character.
+    def self.clamp_percent(strval)
+      value = strval.to_r / 100
+      return 0r if value < 0r
+      return 1r if value > 1r
+      value
+    end
+    
+    def self.clamp_alpha(strval)
+      value = strval.to_r
+      return 0r if value < 0r
+      return 1r if value > 1r
+      value
+    end
+    
+  end
+  
+  class CSS3
+
+    CSS_INT = '[-+]?\d+'
+    CSS_PCT = '[-+]?\d+%'
+    CSS_AFLT = %r/[-+]?\d*[.]?\d+/
+
+    RGB_MATCH = %r/\Argb\((.*)\)\z/
+    RGBA_MATCH = %r/\Argba\((.*)\)\z/
+    HSL_PREMATCH = %r/\Ahsl\((.*)\)\z/
+    HSLA_PREMATCH = %r/\Ahsla\((.*)\)\z/
+    HSL_MATCH  = %r/\Ahsl\( \s* (?<hue>#{CSS_INT}) \s* , \s* (?<saturation>#{CSS_PCT}) \s* , \s* (?<lightness>#{CSS_PCT}) \s* \)\z/x
+    HSLA_MATCH = %r/\Ahsla\( \s* (?<hue>#{CSS_INT}) \s* , \s* (?<saturation>#{CSS_PCT}) \s* , \s* (?<lightness>#{CSS_PCT}) \s* , \s* (?<alpha>#{CSS_AFLT}) \s* \)\z/x
+
+    
+    # Factory method for generating RGB/RGBA/HSL/HSLA Objects.
+    # Parsing based on spec https://www.w3.org/TR/css-color-3 ; section 4.2
+                                    
+    def self.parse(css_string)
+      error_message = "must be a string of `rgb(rr,gg,bb)`, `rgba(rr,gg,bb,aa)`, `hsl(hh,ss,ll)`, or `hsla(hh,ss,ll,aa)` form"
+      unless css_string.respond_to?(:to_str)
+        raise ArgumentError, "#{error_message}: #{css_string.inspect}"
+      end
+
+      css_string = css_string.to_str.strip
+
+      case css_string
+      when RGB_MATCH
+        rgb = RGB_MATCH.match(css_string)[1].strip.split(/\s*,\s*/)
+        raise ArgumentError, "Expecting 3 fields for rgb(): #{css_string.inspect}" if rgb.length != 3
+        num_percent_vals = rgb.count { |v| v[-1] == '%' }
+        r, g, b = if num_percent_vals == 0
+                    rgb.map { |c| CSSUtil.clamp_int(c) }
+                  elsif num_percent_vals == 3
+                    rgb.map { |c| CSSUtil.clamp_percent(c) }
+                  else
+                    raise ArgumentError, "Invalid mix of percent and integer values:  #{css_string.inspect}"
+                  end
+        return RGB.new(r, g, b)
+      when RGBA_MATCH
+        rgba = RGBA_MATCH.match(css_string)[1].strip.split(/\s*,\s*/)
+        raise ArgumentError, "Expecting 4 fields for rgba(): #{css_string.inspect}" if rgba.length != 4
+        rgb = rgba[0..2]
+        num_percent_vals = rgb.count { |v| v[-1] == '%' }
+        if num_percent_vals == 0
+          r, g, b = rgb.map { |c| CSSUtil.clamp_int(c) }
+          # note, RGBA.new expects all values to be integers or floats.
+          # for this case, we turn the alpha-value into an int range 0..255 to match the r,g,b values.
+          a = (CSSUtil.clamp_alpha(rgba[3]) * 255).to_i
+        elsif num_percent_vals == 3
+          r, g, b = rgb.map { |c| CSSUtil.clamp_percent(c) }
+          a = CSSUtil.clamp_alpha(rgba[3])
+        else
+          raise ArgumentError, "Invalid mix of percent and integer values:  #{css_string.inspect}"
+        end
+        return RGBA.new(r, g, b, a)
+      when HSL_PREMATCH
+        matcher = HSL_MATCH.match(css_string)
+        raise ArgumentError, "Bad hsl(): #{css_string.inspect}" unless matcher
+        # CSS Hue values are an angle, unclear if we should convert to int or float
+        h = matcher[:hue].to_i
+        s, l = %i[saturation lightness].map { |c| CSSUtil.clamp_percent(matcher[c]) }
+        return HSL.new(h, s, l)
+      when HSLA_PREMATCH
+        matcher = HSLA_MATCH.match(css_string)
+        raise ArgumentError, "Bad hsla(): #{css_string.inspect}" unless matcher
+        h = matcher[:hue].to_i
+        s, l = %i[saturation lightness].map { |c| CSSUtil.clamp_percent(matcher[c]) }
+        a = CSSUtil.clamp_alpha(matcher[:alpha])
+        return HSLA.new(h, s, l, a)
+      else
+        raise ArgumentError, "#{error_message}: #{css_string.inspect}"
+      end
+    end
+  end
+end  

--- a/lib/colors/css3.rb
+++ b/lib/colors/css3.rb
@@ -1,5 +1,5 @@
 module Colors
-  class CSS3
+  module CSS3
 
     # Factory method for generating RGB/RGBA/HSL/HSLA Objects.
     # Parsing based on spec https://www.w3.org/TR/css-color-3 ; section 4.2

--- a/lib/colors/css3.rb
+++ b/lib/colors/css3.rb
@@ -1,5 +1,5 @@
 module Colors
-  module CSS3
+  module CSS
 
     # Factory method for generating RGB/RGBA/HSL/HSLA Objects.
     # Parsing based on spec https://www.w3.org/TR/css-color-3 ; section 4.2
@@ -12,46 +12,46 @@ module Colors
 
       css_string = css_string.to_str.strip
 
-      matcher = /\A(rgb|rgba|hsl|hsla)\((.*)\)\z/.match(css_string)
+      matcher = /\A((?:rgb|hsl)a?)\(([^)]+)\)\z/.match(css_string)
       unless matcher
         raise ArgumentError, "#{error_message}: #{css_string.inspect}"
       end
       
-      css_type, argstring = matcher[1..2]
-      arglist = argstring.strip.split(/\s*,\s*/)
-      has_alpha = css_type[-1] == 'a' # rgba/hsla
-      if has_alpha && arglist.length != 4
-        raise ArgumentError, "Expecting 4 fields for #{css_type}(): #{css_string.inspect}"
-      elsif !has_alpha && arglist.length != 3
-        raise ArgumentError, "Expecting 3 fields for #{css_type}(): #{css_string.inspect}"
+      color_space, args_string = matcher[1..2]
+      args = args_string.strip.split(/\s*,\s*/)
+      has_alpha = color_space.end_with?("a") # rgba/hsla
+      if has_alpha && args.length != 4
+        raise ArgumentError, "Expecting 4 fields for #{color_space}(): #{css_string.inspect}"
+      elsif !has_alpha && args.length != 3
+        raise ArgumentError, "Expecting 3 fields for #{color_space}(): #{css_string.inspect}"
       end
       
-      case css_type
-      when /rgb/
-        rgb, alpha = arglist[0..2], arglist[3]
-        num_percent_vals = rgb.count { |v| v[-1] == '%' }
+      case color_space
+      when "rgb", "rgba"
+        rgb, alpha = args[0, 3], args[3]
+        num_percent_vals = rgb.count {|v| v.end_with?("%") }
         # CSS3 allows RGB values to be specified with all 3 as a percentage "##%"
         # or all as integer values without '%' sign.
         if num_percent_vals.zero?
           # interpret as integer values in range of 0..255
-          r, g, b = rgb.map { |strval| strval.to_i.clamp(0, 255) }
+          r, g, b = rgb.map {|strval| strval.to_i.clamp(0, 255) }
           # Note, RGBA.new expects all values to be integers or floats.
           # For this case, we also turn the alpha-value into an int range 0..255
           # to match the r,g,b values.
           a = has_alpha && (alpha.to_r.clamp(0r, 1r) * 255).to_i
         elsif num_percent_vals == 3
-          r, g, b = rgb.map { |strval| (strval.to_r / 100).clamp(0r, 1r) }
+          r, g, b = rgb.map {|strval| (strval.to_r / 100).clamp(0r, 1r) }
           a = has_alpha && alpha.to_r.clamp(0r, 1r)
         else
-          raise ArgumentError, "Invalid mix of percent and integer values:  #{css_string.inspect}"
+          raise ArgumentError, "Invalid mix of percent and integer values: #{css_string.inspect}"
         end
         return has_alpha ? RGBA.new(r, g, b, a) : RGB.new(r, g, b)
         
-      when /hsl/
-        hue, sat, light, alpha = *arglist
+      when "hsl", "hsla"
+        hue, sat, light, alpha = *args
         # CSS3 Hue values are an angle, unclear if we should convert to Integer or Rational here.
         h = hue.to_r
-        s, l = [sat, light].map { |strval| (strval.to_r / 100).clamp(0r, 1r) }
+        s, l = [sat, light].map {|strval| (strval.to_r / 100).clamp(0r, 1r) }
         if has_alpha
           a = alpha.to_r.clamp(0r, 1r)
           return HSLA.new(h, s, l, a)
@@ -59,7 +59,7 @@ module Colors
           return HSL.new(h, s, l)
         end
       else
-        raise "Illegal condition"
+        raise ArgumentError, "Unknown color space: #{css_string.inspect}"
       end
     end
   end

--- a/lib/colors/css3.rb
+++ b/lib/colors/css3.rb
@@ -1,27 +1,4 @@
 module Colors
-
-  module CSSUtil
-
-    # For RGB, CSS clamps values at min=0, max=255
-    def self.clamp_int(strval)
-      [[strval.to_i, 0].max, 255].min
-    end
-    
-    # Rationalize a percentage string, e.g.:  "1.2%"
-    # takes advantage of #to_r ignoring the '%' character.
-    # Clamp between 0r and 1r
-    def self.clamp_percent(strval)
-      [[strval.to_r / 100, 0r].max, 1r].min
-    end
-    
-    # Rationalize alpha value.
-    # Clamp between 0r and 1r
-    def self.clamp_alpha(strval)
-      [[strval.to_r, 0r].max, 1r].min
-    end
-    
-  end
-  
   class CSS3
 
     # Factory method for generating RGB/RGBA/HSL/HSLA Objects.
@@ -34,49 +11,55 @@ module Colors
       end
 
       css_string = css_string.to_str.strip
+
       matcher = /\A(rgb|rgba|hsl|hsla)\((.*)\)\z/.match(css_string)
-      if matcher
-        css_type, argstring = matcher[1..2]
-        arglist = argstring.strip.split(/\s*,\s*/)
-        has_alpha = css_type[-1] == 'a' # rgba/hsla
-        if has_alpha && arglist.length !=4
-          raise ArgumentError, "Expecting 4 fields for #{css_type}(): #{css_string.inspect}"
-        elsif !has_alpha && arglist.length !=3
-          raise ArgumentError, "Expecting 3 fields for #{css_type}(): #{css_string.inspect}"
-        end
-          
-        case css_type
-        when /rgb/
-          rgb, alpha =  arglist[0..2], arglist[3]
-          num_percent_vals = rgb.count { |v| v[-1] == '%' }
-          # CSS3 allows RGB values to be specified with all 3 as a percentage "##%"
-          # or all as integer values without '%' sign.
-          if num_percent_vals == 0
-            r, g, b = rgb.map { |c| CSSUtil.clamp_int(c) }
-            # note, RGBA.new expects all values to be integers or floats.
-            # for this case, we turn the alpha-value into an int range 0..255 to match the r,g,b values.
-            a = alpha ? (CSSUtil.clamp_alpha(alpha) * 255).to_i : nil
-            
-          elsif num_percent_vals == 3
-            r, g, b = rgb.map { |c| CSSUtil.clamp_percent(c) }
-            a = alpha ? CSSUtil.clamp_alpha(alpha) : nil
-          else
-            raise ArgumentError, "Invalid mix of percent and integer values:  #{css_string.inspect}"
-          end
-          return a ? RGBA.new(r, g, b, a) : RGB.new(r, g, b)
-        when /hsl/
-          hue, sat, light, alpha = *arglist
-          # CSS3 Hue values are an angle, unclear if we should convert to Integer or Rational here.
-          h = hue.to_r
-          s, l = [sat, light].map { |c| CSSUtil.clamp_percent(c) }
-          a = alpha ? CSSUtil.clamp_alpha(alpha) : nil
-          return a ? HSLA.new(h, s, l, a) : HSL.new(h, s, l)
-        else
-          raise "Illegal condition"
-        end
-        
-      else
+      unless matcher
         raise ArgumentError, "#{error_message}: #{css_string.inspect}"
+      end
+      
+      css_type, argstring = matcher[1..2]
+      arglist = argstring.strip.split(/\s*,\s*/)
+      has_alpha = css_type[-1] == 'a' # rgba/hsla
+      if has_alpha && arglist.length != 4
+        raise ArgumentError, "Expecting 4 fields for #{css_type}(): #{css_string.inspect}"
+      elsif !has_alpha && arglist.length != 3
+        raise ArgumentError, "Expecting 3 fields for #{css_type}(): #{css_string.inspect}"
+      end
+      
+      case css_type
+      when /rgb/
+        rgb, alpha = arglist[0..2], arglist[3]
+        num_percent_vals = rgb.count { |v| v[-1] == '%' }
+        # CSS3 allows RGB values to be specified with all 3 as a percentage "##%"
+        # or all as integer values without '%' sign.
+        if num_percent_vals.zero?
+          # interpret as integer values in range of 0..255
+          r, g, b = rgb.map { |strval| strval.to_i.clamp(0, 255) }
+          # Note, RGBA.new expects all values to be integers or floats.
+          # For this case, we also turn the alpha-value into an int range 0..255
+          # to match the r,g,b values.
+          a = has_alpha && (alpha.to_r.clamp(0r, 1r) * 255).to_i
+        elsif num_percent_vals == 3
+          r, g, b = rgb.map { |strval| (strval.to_r / 100).clamp(0r, 1r) }
+          a = has_alpha && alpha.to_r.clamp(0r, 1r)
+        else
+          raise ArgumentError, "Invalid mix of percent and integer values:  #{css_string.inspect}"
+        end
+        return has_alpha ? RGBA.new(r, g, b, a) : RGB.new(r, g, b)
+        
+      when /hsl/
+        hue, sat, light, alpha = *arglist
+        # CSS3 Hue values are an angle, unclear if we should convert to Integer or Rational here.
+        h = hue.to_r
+        s, l = [sat, light].map { |strval| (strval.to_r / 100).clamp(0r, 1r) }
+        if has_alpha
+          a = alpha.to_r.clamp(0r, 1r)
+          return HSLA.new(h, s, l, a)
+        else
+          return HSL.new(h, s, l)
+        end
+      else
+        raise "Illegal condition"
       end
     end
   end

--- a/test/test-css3.rb
+++ b/test/test-css3.rb
@@ -1,0 +1,183 @@
+class ColorsCSS3ParserTest < Test::Unit::TestCase
+  include TestHelper
+
+  sub_test_case("rgb") do
+
+    test("simple in-range integer values") do
+      ref = Colors::RGB.new(1, 0, 255)
+      css = Colors::CSS3.parse("rgb(1,0,255)")
+      assert_near(ref, css)
+    end
+
+    test("clamps out-of-range integer values") do
+      ref = Colors::RGB.new(255, 0, 0)
+      css = Colors::CSS3.parse("rgb(   300 ,0,0)")
+      assert_near(ref, css)
+      css = Colors::CSS3.parse("rgb(   255 , -10,0)")
+      assert_near(ref, css)
+    end
+    
+    test("in-range percent values") do
+      ref = Colors::RGB.new(0, 0.55, 1)
+      css = Colors::CSS3.parse("rgb(0%,55%,100%)")
+      assert_near(ref, css)
+    end
+    
+    test("clamps out-of-range percent values") do
+      ref = Colors::RGB.new(0r, 0r, 1r)
+      css = Colors::CSS3.parse("rgb(0%,0%,110%)")
+      assert_near(ref, css)
+      css = Colors::CSS3.parse("rgb(-10%,0%,100%)")
+      assert_near(ref, css)
+    end
+
+    test("bad input") do
+      assert_raises ArgumentError, "mixed pct/int" do
+        Colors::CSS3.parse("rgb(50%,0 ,0)")
+      end
+      assert_raises ArgumentError, "too few args" do
+        Colors::CSS3.parse("rgb(50%,0%)")
+      end
+      assert_raises ArgumentError, "too many args" do
+        Colors::CSS3.parse("rgb(50%,0%,6%,0)")
+      end
+      assert_raises ArgumentError, "missing comma" do
+        Colors::CSS3.parse("rgb(50% 0% 6%)")
+      end
+    end
+
+  end
+
+  sub_test_case("rgba") do
+    
+    test("integer values, int alpha") do
+      ref = Colors::RGBA.new(1r, 0r, 1r, 1r)
+      css = Colors::CSS3.parse("rgba(255,0,255,1)")
+      assert_near(ref, css)
+      ref = Colors::RGBA.new(1r, 0r, 1r, 0r)
+      css = Colors::CSS3.parse("rgba(255,0,255,0)")
+      assert_near(ref, css)
+    end
+
+    test("integer values, float alpha") do
+      ref = Colors::RGBA.new(255, 0, 255, 127)
+      css = Colors::CSS3.parse("rgba(255,0,255 ,   0.5)")
+      assert_near(ref, css)
+    end
+
+    test("clamp out of range alpha values") do
+      ref = Colors::RGBA.new(1r, 0, 1r, 1r)
+      css = Colors::CSS3.parse("rgba(255,0,255,2.0)")
+      assert_near(ref, css)
+      ref = Colors::RGBA.new(1r, 127/255r, 123/255r, 0.0)
+      css = Colors::CSS3.parse("rgba(255, 127, 123,-0.1)")
+      assert_near(ref, css)
+    end
+
+    test("percent values, int alpha") do
+      ref = Colors::RGBA.new(1r, 0r, 0.25r, 1r)
+      css = Colors::CSS3.parse("rgba(100%,0%,25%,1)")
+      assert_near(ref, css)
+      ref = Colors::RGBA.new(1r, 0.33r, 0.02r, 0r)
+      css = Colors::CSS3.parse("rgba(100% , 33%,2%,0)")
+      assert_near(ref, css)
+    end
+
+    test("percent values, float alpha") do
+      ref = Colors::RGBA.new(0.5r, 0, 0.06, 1/2r)
+      css = Colors::CSS3.parse("rgba(50%,0%,6% ,0.5)")
+      assert_near(ref, css)
+    end
+    
+    test("bad input") do
+      assert_raises ArgumentError, "mixed pct/int" do
+        Colors::CSS3.parse("rgba(50%,0,6 ,0.5)")
+      end
+      assert_raises ArgumentError, "too few args" do
+        Colors::CSS3.parse("rgba(50%,0%,6%)")
+      end
+      assert_raises ArgumentError, "too many args" do
+        Colors::CSS3.parse("rgba(50%,0%,6%,0.5, 0.5)")
+      end
+      assert_raises ArgumentError, "missing comma" do
+        Colors::CSS3.parse("rgba(50%,0%,6% 0.5)")
+      end
+    end
+
+  end
+
+  sub_test_case("hsl") do
+    
+    test("in-range hsl") do
+      ref = Colors::HSL.new(180, 0, 0.5)
+      css = Colors::CSS3.parse("hsl( 180, 0% , 50% )")
+      assert_near(ref, css)
+    end
+
+    test("clamps out-of-range integer values") do
+      ref = Colors::HSL.new(180, 0, 0.5)
+      css = Colors::CSS3.parse("hsl(-180,0%,50%)")
+      assert_near(ref, css)
+      css = Colors::CSS3.parse("hsl(180,-10%,50%)")
+      assert_near(ref, css)
+      css = Colors::CSS3.parse("hsl(540,-10%,50%)")
+      assert_near(ref, css)
+      ref = Colors::HSL.new(0, 1.0, 1.0)
+      css = Colors::CSS3.parse("hsl(0,100%,100%)")
+      assert_near(ref, css)
+      css = Colors::CSS3.parse("hsl(360,100%,100%)")
+      assert_near(ref, css)
+    end
+    
+    test("bad input") do
+      assert_raises ArgumentError, "too many args" do
+        css = Colors::CSS3.parse("hsl( 180, 0% , 50%, 50% )")
+      end
+      assert_raises ArgumentError, "too few args" do
+        css = Colors::CSS3.parse("hsl( 180, 0%)")
+      end
+      assert_raises ArgumentError, "missing comma" do
+        css = Colors::CSS3.parse("hsl( 180, 0% 50% )")
+      end
+    end
+  end
+
+  
+  sub_test_case("hsla") do
+    
+    test("in-range hsla") do
+      ref = Colors::HSLA.new(180, 0, 0.5, 1.0)
+      css = Colors::CSS3.parse("hsla( 180, 0% , 50%,1.0)")
+      assert_near(ref, css)
+    end
+
+    test("clamps out-of-range integer values") do
+      ref = Colors::HSLA.new(180, 0, 0.5, 0.1)
+      css = Colors::CSS3.parse("hsla(-180,0%,50%,0.1)")
+      assert_near(ref, css)
+      css = Colors::CSS3.parse("hsla(180,-10%,50%, 0.1)")
+      assert_near(ref, css)
+      css = Colors::CSS3.parse("hsla(540,-10%,50%, 0.1)")
+      assert_near(ref, css)
+      ref = Colors::HSLA.new(0, 1.0, 1.0, 0.0)
+      css = Colors::CSS3.parse("hsla(0,100%,100%,0.0)")
+      assert_near(ref, css)
+      css = Colors::CSS3.parse("hsla(360,100%,100%, 0.0)")
+      assert_near(ref, css)
+    end
+    
+    test("bad input") do
+      assert_raises ArgumentError, "too many args" do
+        css = Colors::CSS3.parse("hsla( 180, 0% , 50%, 0.0, 0.0 )")
+      end
+      assert_raises ArgumentError, "too few args" do
+        css = Colors::CSS3.parse("hsla( 180, 0%, 0.0)")
+      end
+      assert_raises ArgumentError, "missing comma" do
+        css = Colors::CSS3.parse("hsla( 180, 0% 50% 0.0 )")
+      end
+    end
+    
+  end
+  
+end

--- a/test/test-css3.rb
+++ b/test/test-css3.rb
@@ -1,48 +1,48 @@
-class ColorsCSS3ParserTest < Test::Unit::TestCase
+class ColorsCSSParserTest < Test::Unit::TestCase
   include TestHelper
 
   sub_test_case("rgb") do
 
     test("simple in-range integer values") do
       ref = Colors::RGB.new(1, 0, 255)
-      css = Colors::CSS3.parse("rgb(1,0,255)")
+      css = Colors::CSS.parse("rgb(1,0,255)")
       assert_near(ref, css)
     end
 
     test("clamps out-of-range integer values") do
       ref = Colors::RGB.new(255, 0, 0)
-      css = Colors::CSS3.parse("rgb(   300 ,0,0)")
+      css = Colors::CSS.parse("rgb(   300 ,0,0)")
       assert_near(ref, css)
-      css = Colors::CSS3.parse("rgb(   255 , -10,0)")
+      css = Colors::CSS.parse("rgb(   255 , -10,0)")
       assert_near(ref, css)
     end
     
     test("in-range percent values") do
       ref = Colors::RGB.new(0, 0.55, 1)
-      css = Colors::CSS3.parse("rgb(0%,55%,100%)")
+      css = Colors::CSS.parse("rgb(0%,55%,100%)")
       assert_near(ref, css)
     end
     
     test("clamps out-of-range percent values") do
       ref = Colors::RGB.new(0r, 0r, 1r)
-      css = Colors::CSS3.parse("rgb(0%,0%,110%)")
+      css = Colors::CSS.parse("rgb(0%,0%,110%)")
       assert_near(ref, css)
-      css = Colors::CSS3.parse("rgb(-10%,0%,100%)")
+      css = Colors::CSS.parse("rgb(-10%,0%,100%)")
       assert_near(ref, css)
     end
 
     test("bad input") do
       assert_raises ArgumentError, "mixed pct/int" do
-        Colors::CSS3.parse("rgb(50%,0 ,0)")
+        Colors::CSS.parse("rgb(50%,0 ,0)")
       end
       assert_raises ArgumentError, "too few args" do
-        Colors::CSS3.parse("rgb(50%,0%)")
+        Colors::CSS.parse("rgb(50%,0%)")
       end
       assert_raises ArgumentError, "too many args" do
-        Colors::CSS3.parse("rgb(50%,0%,6%,0)")
+        Colors::CSS.parse("rgb(50%,0%,6%,0)")
       end
       assert_raises ArgumentError, "missing comma" do
-        Colors::CSS3.parse("rgb(50% 0% 6%)")
+        Colors::CSS.parse("rgb(50% 0% 6%)")
       end
     end
 
@@ -52,55 +52,55 @@ class ColorsCSS3ParserTest < Test::Unit::TestCase
     
     test("integer values, int alpha") do
       ref = Colors::RGBA.new(1r, 0r, 1r, 1r)
-      css = Colors::CSS3.parse("rgba(255,0,255,1)")
+      css = Colors::CSS.parse("rgba(255,0,255,1)")
       assert_near(ref, css)
       ref = Colors::RGBA.new(1r, 0r, 1r, 0r)
-      css = Colors::CSS3.parse("rgba(255,0,255,0)")
+      css = Colors::CSS.parse("rgba(255,0,255,0)")
       assert_near(ref, css)
     end
 
     test("integer values, float alpha") do
       ref = Colors::RGBA.new(255, 0, 255, 127)
-      css = Colors::CSS3.parse("rgba(255,0,255 ,   0.5)")
+      css = Colors::CSS.parse("rgba(255,0,255 ,   0.5)")
       assert_near(ref, css)
     end
 
     test("clamp out of range alpha values") do
       ref = Colors::RGBA.new(1r, 0, 1r, 1r)
-      css = Colors::CSS3.parse("rgba(255,0,255,2.0)")
+      css = Colors::CSS.parse("rgba(255,0,255,2.0)")
       assert_near(ref, css)
       ref = Colors::RGBA.new(1r, 127/255r, 123/255r, 0.0)
-      css = Colors::CSS3.parse("rgba(255, 127, 123,-0.1)")
+      css = Colors::CSS.parse("rgba(255, 127, 123,-0.1)")
       assert_near(ref, css)
     end
 
     test("percent values, int alpha") do
       ref = Colors::RGBA.new(1r, 0r, 0.25r, 1r)
-      css = Colors::CSS3.parse("rgba(100%,0%,25%,1)")
+      css = Colors::CSS.parse("rgba(100%,0%,25%,1)")
       assert_near(ref, css)
       ref = Colors::RGBA.new(1r, 0.33r, 0.02r, 0r)
-      css = Colors::CSS3.parse("rgba(100% , 33%,2%,0)")
+      css = Colors::CSS.parse("rgba(100% , 33%,2%,0)")
       assert_near(ref, css)
     end
 
     test("percent values, float alpha") do
       ref = Colors::RGBA.new(0.5r, 0, 0.06, 1/2r)
-      css = Colors::CSS3.parse("rgba(50%,0%,6% ,0.5)")
+      css = Colors::CSS.parse("rgba(50%,0%,6% ,0.5)")
       assert_near(ref, css)
     end
     
     test("bad input") do
       assert_raises ArgumentError, "mixed pct/int" do
-        Colors::CSS3.parse("rgba(50%,0,6 ,0.5)")
+        Colors::CSS.parse("rgba(50%,0,6 ,0.5)")
       end
       assert_raises ArgumentError, "too few args" do
-        Colors::CSS3.parse("rgba(50%,0%,6%)")
+        Colors::CSS.parse("rgba(50%,0%,6%)")
       end
       assert_raises ArgumentError, "too many args" do
-        Colors::CSS3.parse("rgba(50%,0%,6%,0.5, 0.5)")
+        Colors::CSS.parse("rgba(50%,0%,6%,0.5, 0.5)")
       end
       assert_raises ArgumentError, "missing comma" do
-        Colors::CSS3.parse("rgba(50%,0%,6% 0.5)")
+        Colors::CSS.parse("rgba(50%,0%,6% 0.5)")
       end
     end
 
@@ -110,34 +110,34 @@ class ColorsCSS3ParserTest < Test::Unit::TestCase
     
     test("in-range hsl") do
       ref = Colors::HSL.new(180, 0, 0.5)
-      css = Colors::CSS3.parse("hsl( 180, 0% , 50% )")
+      css = Colors::CSS.parse("hsl( 180, 0% , 50% )")
       assert_near(ref, css)
     end
 
     test("clamps out-of-range integer values") do
       ref = Colors::HSL.new(180, 0, 0.5)
-      css = Colors::CSS3.parse("hsl(-180,0%,50%)")
+      css = Colors::CSS.parse("hsl(-180,0%,50%)")
       assert_near(ref, css)
-      css = Colors::CSS3.parse("hsl(180,-10%,50%)")
+      css = Colors::CSS.parse("hsl(180,-10%,50%)")
       assert_near(ref, css)
-      css = Colors::CSS3.parse("hsl(540,-10%,50%)")
+      css = Colors::CSS.parse("hsl(540,-10%,50%)")
       assert_near(ref, css)
       ref = Colors::HSL.new(0, 1.0, 1.0)
-      css = Colors::CSS3.parse("hsl(0,100%,100%)")
+      css = Colors::CSS.parse("hsl(0,100%,100%)")
       assert_near(ref, css)
-      css = Colors::CSS3.parse("hsl(360,100%,100%)")
+      css = Colors::CSS.parse("hsl(360,100%,100%)")
       assert_near(ref, css)
     end
     
     test("bad input") do
       assert_raises ArgumentError, "too many args" do
-        css = Colors::CSS3.parse("hsl( 180, 0% , 50%, 50% )")
+        css = Colors::CSS.parse("hsl( 180, 0% , 50%, 50% )")
       end
       assert_raises ArgumentError, "too few args" do
-        css = Colors::CSS3.parse("hsl( 180, 0%)")
+        css = Colors::CSS.parse("hsl( 180, 0%)")
       end
       assert_raises ArgumentError, "missing comma" do
-        css = Colors::CSS3.parse("hsl( 180, 0% 50% )")
+        css = Colors::CSS.parse("hsl( 180, 0% 50% )")
       end
     end
   end
@@ -147,34 +147,34 @@ class ColorsCSS3ParserTest < Test::Unit::TestCase
     
     test("in-range hsla") do
       ref = Colors::HSLA.new(180, 0, 0.5, 1.0)
-      css = Colors::CSS3.parse("hsla( 180, 0% , 50%,1.0)")
+      css = Colors::CSS.parse("hsla( 180, 0% , 50%,1.0)")
       assert_near(ref, css)
     end
 
     test("clamps out-of-range integer values") do
       ref = Colors::HSLA.new(180, 0, 0.5, 0.1)
-      css = Colors::CSS3.parse("hsla(-180,0%,50%,0.1)")
+      css = Colors::CSS.parse("hsla(-180,0%,50%,0.1)")
       assert_near(ref, css)
-      css = Colors::CSS3.parse("hsla(180,-10%,50%, 0.1)")
+      css = Colors::CSS.parse("hsla(180,-10%,50%, 0.1)")
       assert_near(ref, css)
-      css = Colors::CSS3.parse("hsla(540,-10%,50%, 0.1)")
+      css = Colors::CSS.parse("hsla(540,-10%,50%, 0.1)")
       assert_near(ref, css)
       ref = Colors::HSLA.new(0, 1.0, 1.0, 0.0)
-      css = Colors::CSS3.parse("hsla(0,100%,100%,0.0)")
+      css = Colors::CSS.parse("hsla(0,100%,100%,0.0)")
       assert_near(ref, css)
-      css = Colors::CSS3.parse("hsla(360,100%,100%, 0.0)")
+      css = Colors::CSS.parse("hsla(360,100%,100%, 0.0)")
       assert_near(ref, css)
     end
     
     test("bad input") do
       assert_raises ArgumentError, "too many args" do
-        css = Colors::CSS3.parse("hsla( 180, 0% , 50%, 0.0, 0.0 )")
+        css = Colors::CSS.parse("hsla( 180, 0% , 50%, 0.0, 0.0 )")
       end
       assert_raises ArgumentError, "too few args" do
-        css = Colors::CSS3.parse("hsla( 180, 0%, 0.0)")
+        css = Colors::CSS.parse("hsla( 180, 0%, 0.0)")
       end
       assert_raises ArgumentError, "missing comma" do
-        css = Colors::CSS3.parse("hsla( 180, 0% 50% 0.0 )")
+        css = Colors::CSS.parse("hsla( 180, 0% 50% 0.0 )")
       end
     end
     


### PR DESCRIPTION
@mrkn per issue #5 and CSS3 spec, this adds support for rgb(), rgba(), hsl() and hsla().
Organization of the code may need some work.  Tests included to cover range-clamping described in the CSS spec.